### PR TITLE
Fix pep8 deprecation warning

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 check-manifest
 coverage
-pep8
+pycodestyle
 pyflakes

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,9 +1,11 @@
 [bdist_wheel]
 universal = true
 
-[pep8]
+[pycodestyle]
 # E129: indentation between lines in conditions
 # E261: two spaces before inline comment
 # E301: expected blank line
 # E302: two new lines between functions/etc.
-ignore = E129,E261,E301,E302
+# E305: two new lines between functions/etc.
+# E741: ambiguous variable name 'l'
+ignore = E129,E261,E301,E302,E305,E741

--- a/tests/pep8.t
+++ b/tests/pep8.t
@@ -1,7 +1,7 @@
 Skip this test if pep8 isn't available:
 
-  $ command -v pep8 > /dev/null || exit 80
+  $ command -v pycodestyle > /dev/null || exit 80
 
 Check that the Python source code style is PEP 8 compliant:
 
-  $ pep8 --config="$TESTDIR/.."/setup.cfg --repeat "$TESTDIR/.."
+  $ pycodestyle --config="$TESTDIR/.."/setup.cfg --repeat "$TESTDIR/.."


### PR DESCRIPTION
`make test` fails with a current version of `pep8` installed (e.g. on Travis), because the `pep8` tool is deprecated and outputs a warning about switching to pycodestyle.  This patch switches cram to use pycodestyle and suppresses additional warnings, making it possible for `make test` to run without errors.