### PR TITLE
PEP 8 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-COVERAGE=coverage
+COVERAGE?=coverage
 PREFIX=/usr/local
 export PREFIX
-PYTHON=python
+PYTHON?=python
 
 all: build
 

--- a/cram/_diff.py
+++ b/cram/_diff.py
@@ -59,18 +59,18 @@ def glob(el, l):
     """Apply a glob match to a line annotated with '(glob)'"""
     return _matchannotation('glob', _glob, el, l)
 
-def esc(el, l):
+def esc(el, line):
     """Apply an escape match to a line annotated with '(esc)'"""
     ann = b(' (esc)\n')
 
     if el.endswith(ann):
         el = codecs.escape_decode(el[:-len(ann)])[0] + b('\n')
-    if el == l:
+    if el == line:
         return True
 
-    if l.endswith(ann):
-        l = codecs.escape_decode(l[:-len(ann)])[0] + b('\n')
-    return el == l
+    if line.endswith(ann):
+        line = codecs.escape_decode(line[:-len(ann)])[0] + b('\n')
+    return el == line
 
 class _SequenceMatcher(difflib.SequenceMatcher, object):
     """Like difflib.SequenceMatcher, but supports custom match functions"""

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [bdist_wheel]
 universal = true
 
-[pep8]
+[pycodestyle]
 # E129: indentation between lines in conditions
 # E261: two spaces before inline comment
 # E301: expected blank line

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ def long_description():
     """Get the long description from the README"""
     return open(os.path.join(sys.path[0], 'README.rst')).read()
 
+
 setup(
     author='Brodie Rao',
     author_email='brodie@bitheap.org',

--- a/tests/config.t
+++ b/tests/config.t
@@ -28,7 +28,7 @@ Invalid option in .cramrc:
   $ cram
   [Uu]sage: cram \[OPTIONS\] TESTS\.\.\. (re)
   
-  cram: error: option --indent: invalid integer value: 'hmm'
+  cram: error: option --indent: invalid integer value: u'hmm'
   [2]
   $ rm .cramrc
   $ cat > .cramrc <<EOF
@@ -38,7 +38,7 @@ Invalid option in .cramrc:
   $ cram
   [Uu]sage: cram \[OPTIONS\] TESTS\.\.\. (re)
   
-  cram: error: --verbose: invalid boolean value: 'hmm'
+  cram: error: --verbose: invalid boolean value: u'hmm'
   [2]
   $ rm .cramrc
 

--- a/tests/run-doctests.py
+++ b/tests/run-doctests.py
@@ -33,6 +33,7 @@ def rundoctests(pkgdir):
         totaltests += tests
     return totalfailures != 0
 
+
 if __name__ == '__main__':
     try:
         sys.exit(rundoctests(sys.argv[1]))


### PR DESCRIPTION
Adapt to recent PEP 8 updates.
Make COVERAGE and PYTHON overridable in Makefile.