### PR TITLE
Read arguments from a script instead of stdin

### DIFF
--- a/examples/env.t
+++ b/examples/env.t
@@ -23,6 +23,7 @@ Check environment variables:
   fail.t
   missingeol.t
   skip.t
+  stdin.t
   test.t
   $ echo "$TESTFILE"
   env.t

--- a/examples/stdin.t
+++ b/examples/stdin.t
@@ -1,0 +1,9 @@
+Test that consumes stdin. Cram should not fail on this:
+
+  $ echo 123
+  123
+  $ cat > /dev/null
+  $ echo 456
+  456
+  $ echo 789
+  789

--- a/tests/debug.t
+++ b/tests/debug.t
@@ -24,8 +24,10 @@ Debug mode:
 
 Debug mode with extra shell arguments:
 
-  $ cram --shell-opts='-s' -d debug.t
+  $ cram --shell-opts='-v' -d debug.t
+  echo hi
   hi
+  echo bye
   bye
 
 Test debug mode with set -x:

--- a/tests/test.t
+++ b/tests/test.t
@@ -5,8 +5,8 @@ Set up cram alias and example tests:
 Run cram examples:
 
   $ cram -q examples examples/fail.t
-  .s.!.s.
-  # Ran 7 tests, 2 skipped, 1 failed.
+  .s.!.s..
+  # Ran 8 tests, 2 skipped, 1 failed.
   [1]
   $ md5 examples/fail.t examples/fail.t.err
   .*\b0f598c2b7b8ca5bcb8880e492ff6b452\b.* (re)
@@ -16,8 +16,8 @@ Run cram examples:
 Run examples with bash:
 
   $ cram --shell=/bin/bash -q examples examples/fail.t
-  .s.!.s.
-  # Ran 7 tests, 2 skipped, 1 failed.
+  .s.!.s..
+  # Ran 8 tests, 2 skipped, 1 failed.
   [1]
   $ md5 examples/fail.t examples/fail.t.err
   .*\b0f598c2b7b8ca5bcb8880e492ff6b452\b.* (re)
@@ -33,8 +33,9 @@ Verbose mode:
   examples/fail.t: failed
   examples/missingeol.t: passed
   examples/skip.t: skipped
+  examples/stdin.t: passed
   examples/test.t: passed
-  # Ran 7 tests, 2 skipped, 1 failed.
+  # Ran 8 tests, 2 skipped, 1 failed.
   [1]
   $ md5 examples/fail.t examples/fail.t.err
   .*\b0f598c2b7b8ca5bcb8880e492ff6b452\b.* (re)

--- a/tests/xunit.t
+++ b/tests/xunit.t
@@ -11,13 +11,14 @@ xUnit XML output:
   examples/fail.t: failed
   examples/missingeol.t: passed
   examples/skip.t: skipped
+  examples/stdin.t: passed
   examples/test.t: passed
-  # Ran 7 tests, 2 skipped, 1 failed.
+  # Ran 8 tests, 2 skipped, 1 failed.
   [1]
   $ cat cram.xml
   <?xml version="1.0" encoding="utf-8"?>
   <testsuite name="cram"
-             tests="7"
+             tests="8"
              failures="1"
              skipped="2"
              timestamp="\d+-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}" (re)
@@ -81,6 +82,9 @@ xUnit XML output:
               time="\d+\.\d{6}"> (re)
       <skipped/>
     </testcase>
+    <testcase classname="examples/stdin.t"
+              name="stdin.t"
+              time="\d+\.\d{6}"/> (re)
     <testcase classname="examples/test.t"
               name="test.t"
               time="\d+\.\d{6}"/> (re)


### PR DESCRIPTION
If a program under test reads stdin (e.g. by accident), then cram's
current behavior can be a little confusing, since what will happen is
that it'll omit running anything because the script has been read.

For example, if your test file is

```
  $ echo 123
  123
  $ cat > /dev/null
  $ echo 456
  456
  $ echo 789
  789
```

Then running it yields:

```
   $ echo 123
   123
   $ cat > /dev/null
   $ echo 456
-  456
-  $ echo 789
-  789
```

This patch updates cram to pass the script via file instead, which makes
this mistake harder to make. I've also updated one of the tests that was
implicitly relying on this (`debug.t`).